### PR TITLE
Allow fsconsul to parse the updated template syntax used by gosecret.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 go:
 - 1.4
 before_script:
-- wget  https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip
-- unzip 0.5.2_linux_amd64.zip
+- wget  https://releases.hashicorp.com/consul/0.6.3/consul_0.6.3_linux_amd64.zip
+- unzip consul_0.6.3_linux_amd64.zip
 - mkdir consul_data
 - ./consul agent -server -bootstrap -data-dir=consul_data -config-file=test_data/consul-config.json &
 - sleep 5

--- a/template_functions.go
+++ b/template_functions.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	gosecret "github.com/cimpress-mcp/gosecret/api"
+)
+
+func goEncryptFunc(keystore string) func(...string) (string, error) {
+	return func(s ...string) (string, error) {
+		dt, err := gosecret.ParseEncrytionTag(keystore, s...)
+		if err != nil {
+			fmt.Println("Unable to parse encryption tag", err)
+			return "", err
+		}
+
+		return (fmt.Sprintf("{{goDecrypt \"%s\" \"%s\" \"%s\" \"%s\"}}",
+			dt.AuthData,
+			base64.StdEncoding.EncodeToString(dt.CipherText),
+			base64.StdEncoding.EncodeToString(dt.InitVector),
+			dt.KeyName)), nil
+	}
+}
+
+func goDecryptFunc(keystore string) func(...string) (string, error) {
+	return func(s ...string) (string, error) {
+		plaintext, err := gosecret.ParseDecryptionTag(keystore, s...)
+		if err != nil {
+			fmt.Println("Unable to parse encryption tag", err)
+			return "", err
+		}
+
+		return fmt.Sprintf("%s", plaintext), nil
+	}
+}

--- a/test_data/decrypted_file
+++ b/test_data/decrypted_file
@@ -1,0 +1,8 @@
+#This is a sample configuration file for testing fsconsul decrypt
+
+application.setting.1=something
+application.setting.2=something else
+application.secret.1=Sssshh This is a secret!
+application.secret.2=This is even more secret!
+
+#EOF

--- a/test_data/encrypted_file
+++ b/test_data/encrypted_file
@@ -1,0 +1,8 @@
+#This is a sample configuration file for testing fsconsul decrypt
+
+application.setting.1=something
+application.setting.2=something else
+application.secret.1={{goDecrypt "application.secret.1" "3bxdJwjl9EkJb6bqZ5oHGEjr+G9mBvMVvViysOUThCOTr/tvQAvJ1Q==" "AsFkpwx07oaLHjoY" "fsconsul_test_key"}}
+application.secret.2=[gosecret|application.secret.2|S3uKZNpMv3gRYPeIXm6HLFVR+fLzEzu8j68WQ7+/OeGvm3HvAsvDIjM=|EMCkFtxTtxacGR5m|fsconsul_test_key]
+
+#EOF

--- a/test_data/ks/fsconsul_test_key
+++ b/test_data/ks/fsconsul_test_key
@@ -1,0 +1,1 @@
+MpnZEL7HfHhqmd4AK/S/1i/SI41iaJT3Cc+ziKXaP7Q=


### PR DESCRIPTION
The latest version of gosecret changed tags from [] to {{ }} and
adopted the go template library. However gosecret no longer generates
these tags so it becomes a burdon to convert gosecret docs to the old
tags for use with fsconsul. This was my least resistance approach to
merging the capabilites of gosercret into the fsconsul watcher. Feel
free to augment to your style.